### PR TITLE
v0.0.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,251 @@
+name: 🧪 Release
+
+on:
+  push:
+    branches:
+      - main
+      - feat/serde_yml
+  pull_request:
+    branches:
+      - feat/serde_yml
+  release:
+    types: [created]
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Build the project for all the targets and generate artifacts.
+  build:
+    # This job builds the project for all the targets and generates a
+    # release artifact that contains the binaries for all the targets.
+    name: ❯ Build 🛠
+
+    # Only run this job on the main branch when a commit is pushed.
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    # Set up the job environment variables.
+    env:
+      BUILD_ID: ${{ github.run_id }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_API_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      OS: ${{ matrix.platform.os }}
+      TARGET: ${{ matrix.platform.target }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+
+    runs-on: ${{ matrix.platform.os }}
+
+    steps:
+      # Check out the repository code.
+      - name: Checkout sources
+        id: checkout
+        uses: actions/checkout@v4
+
+      # Install the stable Rust toolchain.
+      - name: Install stable toolchain
+        id: install-toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      # Cache dependencies to speed up subsequent builds.
+      - name: Cache dependencies
+        id: cache-dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      # Install the targets for the cross-compilation toolchain
+      - name: Install target
+        id: install-target
+        run: rustup target add ${{ env.TARGET }}
+
+      # Build the targets
+      - name: Build targets
+        id: build-targets
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose --workspace --release --target ${{ env.TARGET }}
+
+      # Package the binary for each target
+      - name: Package the binary
+        id: package-binary
+        run: |
+          mkdir -p target/package
+          tar czf target/package/${{ env.TARGET }}.tar.gz -C target/${{ env.TARGET }}/release .
+          echo "${{ env.TARGET }}.tar.gz=target/package/${{ env.TARGET }}.tar.gz" >> $GITHUB_ENV
+
+      # Upload the binary for each target
+      - name: Upload the binary
+        id: upload-binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.TARGET }}.tar.gz
+          path: target/package/${{ env.TARGET }}.tar.gz
+
+  # Release the binary to GitHub Releases
+  release:
+    name: ❯ Release 🚀
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the repository code
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      # Install the stable Rust toolchain
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      # Update the version number based on the Cargo.toml file
+      - name: Update version number
+        run: |
+          NEW_VERSION=$(grep version Cargo.toml | sed -n 2p | cut -d '"' -f 2)
+          echo "VERSION=$NEW_VERSION" >> "$GITHUB_ENV"
+        shell: /bin/bash -e {0}
+
+      # Cache dependencies to speed up subsequent builds
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      # Download the artifacts from the build job
+      - name: Download artifacts
+        run: |
+          for target in ${{ env.TARGET }}; do
+            echo "Downloading $target artifact"
+            name="${target}.tar.gz"
+            echo "Artifact name: $name"
+            mkdir -p target/package
+            curl -sSL -H "Authorization: token ${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3+json" -L "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/runs/${BUILD_ID}/artifacts/${name}" -o "target/package/${name}"
+          done
+
+        env:
+          VERSION: ${{ env.VERSION }}
+          TARGET: ${{ env.TARGET }}
+          OS: ${{ env.OS }}
+
+      # Generate the changelog based on the git log
+      - name: Generate Changelog
+        id: generate-changelog
+        env:
+          BUILD_ID: ${{ github.run_id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_URL: https://github.com/sebastienrousseau/serde_yml/releases
+          TARGET: ${{ env.TARGET }}
+
+        run: |
+          if [[ ! -f CHANGELOG.md ]]; then
+            # Set path to changelog file
+            changelog_file="${{ github.workspace }}/CHANGELOG.md"
+
+            # Get version from Cargo.toml
+            version=$(grep version Cargo.toml | sed -n 2p | cut -d '"' -f 2)
+
+            # Append version information to changelog
+            echo "## Release v${version} - $(date +'%Y-%m-%d')" >> "${changelog_file}"
+
+            # Copy content of template file to changelog
+            cat TEMPLATE.md >> "${changelog_file}"
+
+            # Append git log to changelog
+            echo "$(git log --pretty=format:'%s' --reverse HEAD)" >> "${changelog_file}"
+
+            # Append empty line to changelog
+            echo "" >> "${changelog_file}"
+
+          fi
+        shell: bash
+
+      # Create the release on GitHub releases
+      - name: Create Release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ env.VERSION }}
+        with:
+          tag_name: v${{ env.VERSION }}
+          release_name: Serde YML 🦀 v${{ env.VERSION }}
+          body_path: ${{ github.workspace }}/CHANGELOG.md
+          draft: true
+          prerelease: false
+
+  # Publish the release to Crates.io automatically
+  crate:
+    name: ❯ Crate.io 🦀
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: release
+    runs-on: ubuntu-latest
+
+    steps:
+      # Check out the repository code
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Install the stable Rust toolchain
+      - name: Install stable toolchain
+        id: install-toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      # Cache dependencies to speed up subsequent builds
+      - name: Cache dependencies
+        id: cache-dependencies
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/.cargo/registry/index/
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-index-
+
+      # Update the version number based on the Cargo.toml file
+      - name: Update version number
+        id: update-version
+        run: |
+          NEW_VERSION=$(grep version Cargo.toml | sed -n 2p | cut -d '"' -f 2)
+          echo "VERSION=$NEW_VERSION" >> "$GITHUB_ENV"
+        shell: /bin/bash -e {0}
+
+      # Log in to crates.io
+      - name: Log in to crates.io
+        id: login-crate-io
+        run: cargo login ${{ secrets.CARGO_API_TOKEN }}
+
+      # Publish the Rust library to Crate.io
+      - name: Publish Library to Crate.io
+        id: publish-library
+        uses: actions-rs/cargo@v1
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_API_TOKEN }}
+        with:
+          command: publish
+          args: "--no-verify --allow-dirty"
+          use-cross: false

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![GitHub][github-badge]][06]
 [![Crates.io][crates-badge]][07]
 [![Docs.rs][docs-badge]][08]
-[![Build Status][build-badge]][06]
 [![Codecov][codecov-badge]][09]
+[![Build Status][build-badge]][10]
 
 A Rust library for using the [Serde][01] serialization framework with data in
 [YAML][05] file format. This project, has been renamed to [Serde YML][00] to
@@ -613,10 +613,11 @@ be dual licensed as above, without any additional terms or conditions.
 [04]: https://github.com/sebastienrousseau/serde_yml/releases
 [05]: https://yaml.org/
 [06]: https://github.com/sebastienrousseau/serde_yml
-[09]: https://codecov.io/gh/sebastienrousseau/serde_yml
 [07]: https://crates.io/crates/serde_yml
 [08]: https://docs.rs/serde_yml
-[build-badge]: https://img.shields.io/github/actions/workflow/status/sebastienrousseau/serde_yml/ci.yml?branch=master&style=for-the-badge "Build Status"
+[09]: https://codecov.io/gh/sebastienrousseau/serde_yml
+[10]: https://github.com/sebastienrousseau/serde-yml/actions?query=branch%3Amain
+[build-badge]: https://img.shields.io/github/actions/workflow/status/sebastienrousseau/serde_yml/release.yml?branch=master&style=for-the-badge "Build Status"
 [codecov-badge]: https://img.shields.io/codecov/c/github/sebastienrousseau/serde_yml?style=for-the-badge&token=Q9KJ6XXL67 "Codecov"
 [crates-badge]: https://img.shields.io/crates/v/serde_yml.svg?style=for-the-badge&color=fc8d62&logo=rust "Crates.io"
 [docs-badge]: https://img.shields.io/badge/docs.rs-serde__yml-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs "Docs.rs"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ serde = "1.0"
 serde_yml = "0.0.8"
 ```
 
-Release notes are available under [04].
+Release notes are available under [GitHub releases][04].
 
 ## Using Serde YAML
 

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -14,7 +14,8 @@ use std::{
 /// A YAML mapping in which the keys and values are both `serde_yml::Value`.
 #[derive(Clone, Default, Eq, PartialEq)]
 pub struct Mapping {
-    map: IndexMap<Value, Value>,
+    /// The underlying map.
+    pub map: IndexMap<Value, Value>,
 }
 
 impl Mapping {

--- a/tests/test_mapping.rs
+++ b/tests/test_mapping.rs
@@ -1,0 +1,189 @@
+#[cfg(test)]
+mod tests {
+    use serde_yml::mapping::*;
+    use serde_yml::value::Value;
+
+    /// Tests the creation of a new empty `Mapping`.
+    #[test]
+    fn test_mapping_new() {
+        let map = Mapping::new();
+        assert!(map.map.is_empty());
+    }
+
+    /// Tests the creation of a new `Mapping` with a specified capacity.
+    #[test]
+    fn test_mapping_with_capacity() {
+        let capacity = 10;
+        let map = Mapping::with_capacity(capacity);
+        assert!(map.map.is_empty());
+        assert!(map.map.capacity() >= capacity);
+    }
+
+    /// Tests reserving additional capacity in the `Mapping`.
+    #[test]
+    fn test_mapping_reserve() {
+        let mut map = Mapping::new();
+        let additional = 10;
+        map.reserve(additional);
+        assert!(map.map.capacity() >= additional);
+    }
+
+    /// Tests reserving with zero additional capacity.
+    #[test]
+    fn test_mapping_reserve_zero() {
+        let mut map = Mapping::new();
+        let additional = 0;
+        map.reserve(additional);
+        assert!(map.map.capacity() >= additional);
+    }
+
+    /// Tests shrinking the capacity of the `Mapping` to fit its content.
+    #[test]
+    fn test_mapping_shrink_to_fit() {
+        let mut map = Mapping::with_capacity(100);
+        map.shrink_to_fit();
+        assert!(map.map.capacity() <= 100);
+    }
+
+    /// Tests inserting a key-value pair into the `Mapping`.
+    #[test]
+    fn test_mapping_insert() {
+        let mut map = Mapping::new();
+        let key = Value::String("key".to_string());
+        let value = Value::String("value".to_string());
+        assert!(map.insert(key.clone(), value.clone()).is_none());
+        assert_eq!(map.get(&key), Some(&value));
+    }
+
+    /// Tests inserting a key-value pair to update an existing key's value.
+    #[test]
+    fn test_mapping_insert_update() {
+        let mut map = Mapping::new();
+        let key = Value::String("key".to_string());
+        let value1 = Value::String("value1".to_string());
+        let value2 = Value::String("value2".to_string());
+        map.insert(key.clone(), value1.clone());
+        assert_eq!(
+            map.insert(key.clone(), value2.clone()),
+            Some(value1)
+        );
+        assert_eq!(map.get(&key), Some(&value2));
+    }
+
+    /// Tests checking if a key exists in the `Mapping`.
+    #[test]
+    fn test_mapping_contains_key() {
+        let mut map = Mapping::new();
+        let key = Value::String("key".to_string());
+        let value = Value::String("value".to_string());
+        map.insert(key.clone(), value.clone());
+        assert!(map.contains_key(&key));
+    }
+
+    /// Tests checking for a non-existent key in the `Mapping`.
+    #[test]
+    fn test_mapping_contains_key_nonexistent() {
+        let map = Mapping::new();
+        let key = Value::String("key".to_string());
+        assert!(!map.contains_key(&key));
+    }
+
+    /// Tests retrieving the value associated with a key in the `Mapping`.
+    #[test]
+    fn test_mapping_get() {
+        let mut map = Mapping::new();
+        let key = Value::String("key".to_string());
+        let value = Value::String("value".to_string());
+        map.insert(key.clone(), value.clone());
+        assert_eq!(map.get(&key), Some(&value));
+    }
+
+    /// Tests retrieving the value for a non-existent key in the `Mapping`.
+    #[test]
+    fn test_mapping_get_nonexistent() {
+        let map = Mapping::new();
+        let key = Value::String("key".to_string());
+        assert_eq!(map.get(&key), None);
+    }
+
+    /// Tests removing a key-value pair from the `Mapping`.
+    #[test]
+    fn test_mapping_remove() {
+        let mut map = Mapping::new();
+        let key = Value::String("key".to_string());
+        let value = Value::String("value".to_string());
+        map.insert(key.clone(), value.clone());
+        assert_eq!(map.remove(&key), Some(value));
+        assert!(!map.contains_key(&key));
+    }
+
+    /// Tests getting the number of key-value pairs in the `Mapping`.
+    #[test]
+    fn test_mapping_len() {
+        let mut map = Mapping::new();
+        assert_eq!(map.len(), 0);
+        let key = Value::String("key".to_string());
+        let value = Value::String("value".to_string());
+        map.insert(key.clone(), value.clone());
+        assert_eq!(map.len(), 1);
+    }
+
+    /// Tests checking if the `Mapping` is empty.
+    #[test]
+    fn test_mapping_is_empty() {
+        let map = Mapping::new();
+        assert!(map.is_empty());
+        let mut map = Mapping::new();
+        let key = Value::String("key".to_string());
+        let value = Value::String("value".to_string());
+        map.insert(key.clone(), value.clone());
+        assert!(!map.is_empty());
+    }
+
+    /// Tests clearing all key-value pairs from the `Mapping`.
+    #[test]
+    fn test_mapping_clear() {
+        let mut map = Mapping::new();
+        let key = Value::String("key".to_string());
+        let value = Value::String("value".to_string());
+        map.insert(key.clone(), value.clone());
+        map.clear();
+        assert!(map.is_empty());
+    }
+
+    /// Tests iterating over the key-value pairs in the `Mapping`.
+    #[test]
+    fn test_mapping_iter() {
+        let mut map = Mapping::new();
+        let key = Value::String("key".to_string());
+        let value = Value::String("value".to_string());
+        map.insert(key.clone(), value.clone());
+        let mut iter = map.iter();
+        let (iter_key, iter_value) = iter.next().unwrap();
+        assert_eq!(iter_key, &key);
+        assert_eq!(iter_value, &value);
+    }
+
+    /// Tests iterating over multiple key-value pairs in the `Mapping`.
+    #[test]
+    fn test_mapping_iter_multiple() {
+        let mut map = Mapping::new();
+        let key1 = Value::String("key1".to_string());
+        let value1 = Value::String("value1".to_string());
+        let key2 = Value::String("key2".to_string());
+        let value2 = Value::String("value2".to_string());
+        map.insert(key1.clone(), value1.clone());
+        map.insert(key2.clone(), value2.clone());
+        let mut iter = map.iter();
+        let (iter_key1, iter_value1) = iter.next().unwrap();
+        let (iter_key2, iter_value2) = iter.next().unwrap();
+        assert!(
+            (iter_key1 == &key1 && iter_value1 == &value1)
+                || (iter_key1 == &key2 && iter_value1 == &value2)
+        );
+        assert!(
+            (iter_key2 == &key1 && iter_value2 == &value1)
+                || (iter_key2 == &key2 && iter_value2 == &value2)
+        );
+    }
+}


### PR DESCRIPTION
## Release Notes

### Enhancements

#### Forked Serde YAML

- **Hard reset**: Hard reset to the latest @dtolnay [latest release](https://github.com/dtolnay/serde-yaml/commit/2009506d33767dfc88e979d6bc0d53d09f941c94) to keep traceability and retain commits history to the original [Serde YAML](https://github.com/dtolnay/serde-yaml) codebase and credits to the maintainers.
- **Renaming**: This project, has been renamed to `Serde YML` to avoid confusion with the original Serde YAML crate which is now archived and no longer maintained. While `Serde YML` started as a fork of serde-yaml, it has now evolved into a separate library with its own goals and direction in mind and does not intend to replace the original serde-yaml crate.

#### CI Improvements
- **ci(serde-yaml)**: Added a missing release workflow and made minor tweaks to the README for better clarity and documentation. This update ensures smoother and more reliable release processes.
  - Commit: `ci(serde-yaml): :green_heart: add missing release workflow and minor tweaks in README`

#### Testing Enhancements
- **test(serde-yaml)**: Enhanced test coverage by adding new unit tests for `mapping.rs`. These tests ensure the robustness and reliability of the `Mapping` struct and its associated methods.
  - Commit: `test(serde-yaml): :white_check_mark: add new tests for `mapping.rs``
  
- **test(serde-yaml)**: Expanded the test suite by adding comprehensive unit tests for the `ser.rs` module. The new tests cover various serialization scenarios, including scalar values, sequences, maps, nested structures, optional fields, and custom serializers.
  - Commit: `test(serde-yaml): :white_check_mark: add unit tests for the `ser.rs` module`
