### PR TITLE
build: relax dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,20 +38,20 @@ include = [
 
 
 [dependencies]
-indexmap = "2.2.6"
-itoa = "1.0.11"
+indexmap = "2.2.4"
+itoa = "1.0"
 libyml = "0.0.4"
-log = { version = "0.4.22", features = ["std"] }
-memchr = "2.7.4"
-ryu = "1.0.18"
+memchr = { version = "2", default-features = false }
+ryu = "1.0"
 serde = { version = "1.0.204", features = ["derive"] }
-serde_json = "1.0.120"
-tempfile = "3.10.1"
 
 [dev-dependencies]
 anyhow = "1.0.86"
 indoc = "2.0.5"
+log = { version = "0.4.22" }
 serde_derive = "1.0.204"
+serde_json = "1.0.120"
+tempfile = "3.10.1"
 
 [features]
 default = []


### PR DESCRIPTION
## Changes in `Cargo.toml`

- Reduce the minimum version requirement of dependencies. `memchr` can have no default features.
- (breaking) Move dependencies unrelated to functionality (`log`, `serde_json`, `tempfile`) to dev-dependencies.

Related changes about function only covered in tests are *not done* yet.

## Questions about deps and more changes

I found most macros are not necessary for this serde of yml. Could they be just removed, added feature flags, or moved to another crate?

- `macro_directory`, `macro_file`, `macro_get_field`: Could be moved to a utility crate, as they depend on filesystem and different serde formats. Besides, the `Not Found` error message checking in tests can fail where it is not given in English.
- `macro_nested_enum_serde`. Just a one-line shorthand.
- `macro_replace_placeholder`. It does nothing with yml. Just a string utility.
- `macro_from_number`. It may be replaced by a blanket impl:
  ```rust
  impl<T> From<T> for Value
  where
      T: Into<Number>,
  {
      fn from(n: T) -> Self {
          Value::Number(n.into())
      }
  }
  ```
  `macro_partialeq_numeric` does more, but it does not need to be exported either.
- `crate::utilities::directory` is only referer in fs related tests. It should belong to a fs utility crate. `dep::tempfile` and `dep:log` go with it.
- `serde_yml::modules::path::Path` derives `Serialize` only because a test need it. If this derive is stripped, `dep:serde` can have no extra feature enabled.
- `anyhow` only appears in docs. `serde_yml::Result<()>` is adequate here.
- It is surprising that `serde_json` is a dependency in a yml library.

A radical patch can be found in https://github.com/QuadnucYard/serde_yml/tree/relex-deps-radical. I do not include it here.

btw, could you open the issues channel?