### PR TITLE
test(serde_yml): add tests for nested merges

### DIFF
--- a/tests/test_value.rs
+++ b/tests/test_value.rs
@@ -104,6 +104,24 @@ fn test_merge() {
 }
 
 #[test]
+fn test_simple_nested_merge() {
+    let yaml = indoc! {"
+        inner: &inner
+          a: 1
+
+        middle: &middle
+          << : *inner
+
+        outer:
+          << : *middle
+    "};
+
+    let mut value: Value = serde_yml::from_str(yaml).unwrap();
+    value.apply_merge().unwrap();
+    assert_eq!(value["inner"], value["outer"]);
+}
+
+#[test]
 fn test_debug() {
     let yaml = indoc! {"
         'Null': ~

--- a/tests/test_value.rs
+++ b/tests/test_value.rs
@@ -122,6 +122,34 @@ fn test_simple_nested_merge() {
 }
 
 #[test]
+fn test_complex_nested_merge() {
+    let yaml = indoc! {"
+        set_a: &set_a
+          a: 1
+
+        set_b: &set_b
+          b: 2
+
+        nest_a: &nest_a
+          << : *set_a
+
+        nest_b: &nest_b
+          << : *set_b
+
+        outer:
+          << : [*nest_a, *nest_b]
+
+        reference:
+          a: 1
+          b: 2
+    "};
+
+    let mut value: Value = serde_yml::from_str(yaml).unwrap();
+    value.apply_merge().unwrap();
+    assert_eq!(value["reference"], value["outer"]);
+}
+
+#[test]
 fn test_debug() {
     let yaml = indoc! {"
         'Null': ~


### PR DESCRIPTION
Merging (using `<< :`) does not work quite I like expected when there are multiple levels of merges.

In a file like this one:

```yaml
inner: &inner
  a: 1
middle: &middle
  << : *inner
outer:
  << : *middle
```

only the first level of merges is handled on the `outer` field, meaning it contains `{"<< :" : {"a": 1}}` after the merge instead of `{"a": 1}`.

Add tests that check if nested merging works correctly.