### PR TITLE
fix(serde_yml): make Value::apply_merge() work on nested structure by making it recursive

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -647,49 +647,54 @@ impl Value {
     /// assert_eq!(value["tasks"]["start"]["args"], "start");
     /// ```
     pub fn apply_merge(&mut self) -> Result<(), Error> {
-        let mut stack = Vec::new();
-        stack.push(self);
-        while let Some(node) = stack.pop() {
-            match node {
-                Value::Mapping(mapping) => {
-                    let merge_sequence = match mapping.remove("<<") {
-                        Some(Value::Sequence(sequence)) => sequence,
-                        Some(value) => vec![value],
-                        None => vec![],
-                    };
+        match self {
+            Value::Mapping(mapping) => {
+                for value in mapping.values_mut() {
+                    value.apply_merge()?;
+                }
 
-                    for value in merge_sequence {
-                        match value {
-                            Value::Mapping(merge) => {
-                                for (k, v) in merge {
-                                    mapping.entry(k).or_insert(v);
-                                }
-                            }
-                            Value::Sequence(_) => {
-                                return Err(error::new(
-                                    ErrorImpl::SequenceInMergeElement,
-                                ));
-                            }
-                            Value::Tagged(_) => {
-                                return Err(error::new(
-                                    ErrorImpl::TaggedInMerge,
-                                ));
-                            }
-                            _unexpected => {
-                                return Err(error::new(
-                                    ErrorImpl::ScalarInMergeElement,
-                                ));
+                let merge_sequence = match mapping.remove("<<") {
+                    Some(Value::Sequence(sequence)) => sequence,
+                    Some(value) => vec![value],
+                    None => vec![],
+                };
+
+                for value in merge_sequence {
+                    match value {
+                        Value::Mapping(merge) => {
+                            for (k, v) in merge {
+                                mapping.entry(k).or_insert(v);
                             }
                         }
+                        Value::Sequence(_) => {
+                            return Err(error::new(
+                                ErrorImpl::SequenceInMergeElement,
+                            ));
+                        }
+                        Value::Tagged(_) => {
+                            return Err(error::new(
+                                ErrorImpl::TaggedInMerge,
+                            ));
+                        }
+                        _unexpected => {
+                            return Err(error::new(
+                                ErrorImpl::ScalarInMergeElement,
+                            ));
+                        }
                     }
-
-                    stack.extend(mapping.values_mut());
                 }
-                Value::Sequence(sequence) => stack.extend(sequence),
-                Value::Tagged(tagged) => stack.push(&mut tagged.value),
-                _ => {}
             }
+            Value::Sequence(sequence) => {
+                for value in sequence {
+                    value.apply_merge()?;
+                }
+            }
+            Value::Tagged(tagged) => {
+                tagged.value.apply_merge()?;
+            }
+            _ => {}
         }
+
         Ok(())
     }
 }

--- a/tests/test_value.rs
+++ b/tests/test_value.rs
@@ -104,6 +104,24 @@ fn test_merge() {
 }
 
 #[test]
+fn test_simple_nested_merge() {
+    let yaml = indoc! {"
+        inner: &inner
+          a: 1
+
+        middle: &middle
+          << : *inner
+
+        outer:
+          << : *middle
+    "};
+
+    let mut value: Value = serde_yml::from_str(yaml).unwrap();
+    value.apply_merge().unwrap();
+    assert_eq!(value["inner"], value["outer"]);
+}
+
+#[test]
 fn test_debug() {
     let yaml = indoc! {"
         'Null': ~

--- a/tests/test_value.rs
+++ b/tests/test_value.rs
@@ -122,6 +122,34 @@ fn test_simple_nested_merge() {
 }
 
 #[test]
+fn test_complex_nested_merge() {
+    let yaml = indoc! {"
+        set_a: &set_a
+          a: 1
+
+        set_b: &set_b
+          b: 2
+
+        nest_a: &nest_a
+          << : *set_a
+
+        nest_b: &nest_b
+          << : *set_b
+
+        outer:
+          << : [*nest_a, *nest_b]
+
+        reference:
+          a: 1
+          b: 2
+    "};
+
+    let mut value: Value = serde_yml::from_str(yaml).unwrap();
+    value.apply_merge().unwrap();
+    assert_eq!(value["reference"], value["outer"]);
+}
+
+#[test]
 fn test_debug() {
     let yaml = indoc! {"
         'Null': ~


### PR DESCRIPTION
This PR is based on #14, which adds tests for the behavior this PR is trying to fix.

This PR fixes `Value::apply_merge()` not working correctly on nested structures. It does so by applying `apply_merges()` recursively instead of maintaining a custom stack of elements to process on the heap.

The drawback of this change is that the program may run out of stack space when walking very deep structures.
The new code also creates ad-hoc `Vec`s while applying merges, because it made the code shorter and easier to read, possibly at the cost of some performance.