### PR TITLE
Remove dead links after forking project

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ fn main() -> Result<(), serde_yml::Error> {
 
 ## Documentation
 
-For full API documentation, please visit [https://doc.libyml.com/serde-yaml/][04] or [https://docs.rs/serde-yaml][08].
+For full API documentation, please visit [https://docs.rs/serde-yml][08].
 
 ## Rust Version Compatibility
 
@@ -621,7 +621,6 @@ be dual licensed as above, without any additional terms or conditions.
 [01]: https://github.com/serde-rs/serde
 [02]: https://github.com/dtolnay/serde-yaml
 [03]: https://github.com/dtolnay
-[04]: https://doc.libyml.com/serde-yaml/
 [05]: https://yaml.org/
 [06]: https://github.com/sebastienrousseau/serde_yml
 [07]: https://crates.io/crates/serde_yml

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@
 //!
 //!## Documentation
 //!
-//!For full API documentation, please visit [https://doc.libyml.com/serde-yaml/][04] or [https://docs.rs/serde-yaml][08].
+//!For full API documentation, please visit [https://docs.rs/serde-yml][08].
 //!
 //!## Rust Version Compatibility
 //!
@@ -80,9 +80,6 @@
 //!
 //! [00]: https://serdeyml.com
 //! [01]: https://github.com/serde-rs/serde
-//! [02]: https://github.com/dtolnay/serde-yaml
-//! [03]: https://github.com/dtolnay
-//! [04]: https://doc.libyml.com/serde-yaml/
 //! [05]: https://yaml.org/
 //! [06]: https://github.com/sebastienrousseau/serde_yml
 //! [07]: https://crates.io/crates/serde_yml


### PR DESCRIPTION
After forking projects some links was replaced to the new locations, but not all. Some links have no alternative today, so them are removed.

Please, enable **Issues** in the repository. You even don't need to to ask GitHub to unfork project as the was in the past, **Issues** available even on forks, just checked that.