### PR TITLE
Remove `TaggedValue::copy` method because it is fully equivalent to `clone` method

### DIFF
--- a/src/value/tagged.rs
+++ b/src/value/tagged.rs
@@ -41,16 +41,6 @@ pub struct TaggedValue {
     pub value: Value,
 }
 
-impl TaggedValue {
-    /// Creates a new `TaggedValue`.
-    pub fn copy(&self) -> TaggedValue {
-        TaggedValue {
-            tag: self.tag.clone(),
-            value: self.value.clone(),
-        }
-    }
-}
-
 impl Tag {
     /// Creates a new `Tag`.
     pub fn new(string: impl Into<String>) -> Self {

--- a/tests/test_tagged.rs
+++ b/tests/test_tagged.rs
@@ -1,9 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use serde_yml::{
-        value::{tagged::nobang, Tag, TaggedValue},
-        Value,
-    };
+    use serde_yml::value::{tagged::nobang, Tag};
 
     /// Test for creating a new Tag.
     #[test]
@@ -17,16 +14,6 @@ mod tests {
     fn test_try_from_tag() {
         let tag = Tag::try_from(&b"foo"[..]).unwrap();
         assert_eq!(tag.string, "foo");
-    }
-
-    /// Test for copying a TaggedValue.
-    #[test]
-    fn test_tagged_value_copy() {
-        let tag = Tag::new("foo");
-        let value = Value::String("bar".to_owned());
-        let tagged_value = TaggedValue { tag, value };
-        let copied = tagged_value.copy();
-        assert_eq!(tagged_value, copied);
     }
 
     /// Test for removing '!' from a string.


### PR DESCRIPTION
In was introduced in the first god commit 8e6866f43a3f6b4de782b44c5c0d72a15994f63c.

The implementation of `copy` just calls `clone` on both struct fields which is what derived `Clone` implementation already do.