### PR TITLE
minimal reproduceable for "String join would overflow memory bounds"

### DIFF
--- a/src/libyml/parser.rs
+++ b/src/libyml/parser.rs
@@ -350,3 +350,16 @@ impl Drop for ParserPinned<'_> {
         unsafe { sys::yaml_parser_delete(&mut self.sys) }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{de::Progress, loader::Loader};
+
+    #[test]
+    fn can_load_document_with_16_spaces_value() {
+        let hardcoded = "t: a                abc";
+        let progress = Progress::Str(hardcoded);
+        let mut loader = Loader::new(progress).unwrap();
+        let _document = loader.next_document().unwrap();
+    }
+}


### PR DESCRIPTION
This PR is not fixing anything, but I didn't find any other way to report issues; please let me know if there is any other way.

I was seeing some panics when parsing some yaml documents and eventually I reduced to the smallest example I could think of that still shows the problem.
Apparently something like the following yaml makes the parser panic (note 16 spaces between 'a' and 'abc':

```yaml
t: a                abc
```

as far as I know, even if the value is a bit weird, it should still be valid yaml and parse correctly.