### PR TITLE
New API to get anchors and aliases from a document

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,9 @@
 #![crate_type = "lib"]
 
 // Re-export commonly used items from other modules
-pub use crate::de::{from_reader, from_slice, from_str, Deserializer}; // Deserialization functions
+pub use crate::de::{
+    from_reader, from_slice, from_str, Deserializer, DocumentAnchor
+}; // Deserialization functions
 pub use crate::modules::error::{Error, Location, Result}; // Error handling types
 pub use crate::ser::{to_string, to_writer, Serializer, State}; // Serialization functions
 #[doc(inline)]

--- a/tests/test_de.rs
+++ b/tests/test_de.rs
@@ -18,6 +18,7 @@ mod tests {
         loader::Loader,
         modules::error::ErrorImpl,
         Deserializer, Number,
+        DocumentAnchor,
         Value::{self, String as SerdeString},
     };
     use std::{
@@ -94,6 +95,31 @@ mod tests {
         expected.insert("second".to_owned(), 1);
         expected.insert("third".to_owned(), 3);
         test_de(yaml, &expected);
+    }
+
+    #[test]
+    fn test_anchor_api() {
+        let yaml = indoc! {"
+        ---
+        a:
+          enum: &io
+            INPUT: 0
+            OUTPUT: 1
+        b:
+          enum: *io
+        c:
+          enum: *io
+        "};
+        let mut deserializer = Deserializer::from_str(yaml);
+        let document = deserializer.next().unwrap();
+        let anchors = document.anchors().unwrap_or_default();
+        let expected = DocumentAnchor {
+            anchor_name: "io".into(),
+            anchor_path: "/a/enum".into(),
+            aliases: ["/b/enum".into(), "/c/enum".into()].to_vec(),
+        };
+        assert_eq!(anchors.len(), 1);
+        assert_eq!(anchors[0], expected);
     }
 
     #[test]


### PR DESCRIPTION
When deserializing a YAML document, the location and names of anchors and aliases is not preserved. That information is useful, though, as users of the library may want to deduplicate references to the same mapping.

This commit introduces an API that exposes such mappings by parsing the metadata in `struct Document`. The new API has been added to `struct Deserializer` and provides the following signature:

   `pub fn anchors(&self) -> Option<Vec<DocumentAnchor>>`

As an example, given the following YAML document:
```
a:
    enum: &io
        INPUT: 0
        OUTPUT: 1
b:
    enum: *io
c:
    enum: *io
```

this API returns:
```
Some([DocumentAnchor {
    anchor_name: "io",
    anchor_path: "/a/enum",
    aliases: ["/b/enum", "/c/enum"],
}])