### PR TITLE
fix: hard coded CStr pointer type, use ffi::c_char

### DIFF
--- a/src/libyml/parser.rs
+++ b/src/libyml/parser.rs
@@ -288,13 +288,13 @@ unsafe fn convert_event<'input>(
 }
 
 unsafe fn optional_anchor(anchor: *const u8) -> Option<Anchor> {
-    let ptr = NonNull::new(anchor as *mut i8)?;
+    let ptr = NonNull::new(anchor as *mut std::ffi::c_char)?;
     let cstr = CStr::from_ptr(ptr);
     Some(Anchor(Box::from(cstr.to_bytes())))
 }
 
 unsafe fn optional_tag(tag: *const u8) -> Option<Tag> {
-    let ptr = NonNull::new(tag as *mut i8)?;
+    let ptr = NonNull::new(tag as *mut std::ffi::c_char)?;
     let cstr = CStr::from_ptr(ptr);
     Some(Tag(Box::from(cstr.to_bytes())))
 }

--- a/src/libyml/safe_cstr.rs
+++ b/src/libyml/safe_cstr.rs
@@ -73,7 +73,7 @@ impl<'a> CStr<'a> {
     /// # Returns
     ///
     /// A new `CStr` instance representing the input pointer.
-    pub fn from_ptr(ptr: NonNull<i8>) -> Self {
+    pub fn from_ptr(ptr: NonNull<std::ffi::c_char>) -> Self {
         CStr {
             // Cast the input pointer to a `NonNull<u8>` pointer
             ptr: ptr.cast(),


### PR DESCRIPTION
`CStr` have pointers of `i8` on x86{,_64}, which is hardcoded into the code, but `u8` on arm, riscv, etc. causing type mismatches on latter architectures as [seen in tests](https://ci.debian.net/packages/r/rust-serde-yml/).

Use `std::ffi::c_char` instead, which is provided by the standard (core) library and in line with platforms the code is being compiled on.