### PR TITLE
docs(serde_yml): fix rustdoc args for docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,8 @@ rustdoc-args = [
     "--generate-link-to-definition",
     "--cfg", "docsrs",
     "--document-private-items",
-    "--display-warnings"
+    "-Z", "unstable-options",
+    "--display-doctest-warnings"
 ]
 # Build docs with all crate features enabled to cover the entire API.
 all-features = true


### PR DESCRIPTION
The flag "--display-warnings" (added in 1eb2a2f) does not exist and is causing docs.rs to fail to build the documentation for v0.0.12. This changes it to "--display-doctest-warnings", which I assume was the intent. Note that this is an unstable option which requires explicit opt in.