### PR TITLE
ci: unbreak legacy workflows by bumping actions/cache@v4.1.2 → @v4

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
 
       # Configure cache for Cargo
       - name: Cache Cargo registry, index
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4
         id: cache-cargo
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       # Cache dependencies to speed up subsequent builds.
       - name: Cache dependencies
         id: cache-dependencies
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4
         with:
           path: ~/.cargo
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
@@ -129,7 +129,7 @@ jobs:
 
       # Cache dependencies to speed up subsequent builds
       - name: Cache dependencies
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4
         with:
           path: ~/.cargo
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
@@ -220,7 +220,7 @@ jobs:
       # Cache dependencies to speed up subsequent builds
       - name: Cache dependencies
         id: cache-dependencies
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4
         with:
           path: /home/runner/.cargo/registry/index/
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
       # Configure cache
       - name: Configure cache
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/


### PR DESCRIPTION
## Summary

GitHub deprecated \`actions/cache@v4.1.2\` on 2026-05-21. Every PR opened against this repo now fails CI at \"Set up job\" with:

\`\`\`
##[error] This request has been automatically failed because it uses a deprecated version of \`actions/cache: v4.1.2\`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions.
\`\`\`

The five usages live in three legacy per-job workflow files:

- \`.github/workflows/coverage.yml\` (1)
- \`.github/workflows/release.yml\` (3)
- \`.github/workflows/test.yml\` (1)

Bumping the pin from \`@v4.1.2\` to the floating \`@v4\` tag picks up the current minor release (≥ v4.2.0) which is **not deprecated**, restoring CI.

## Why \"prep\" — and why not just merge #52?

[#52](https://github.com/sebastienrousseau/serde_yml/pull/52) (the \`serde_yml 0.0.13\` deprecation shim) **removes these legacy workflows entirely** in favour of a single \`ci.yml\` wrapper that delegates to reusable workflows in \`sebastienrousseau/pipelines\`. That's the real fix.

But because \`pull_request\` workflows are resolved against the **base** branch (master) for security, #52's CI is currently failing on master's broken legacy workflows — even though #52 itself deletes them. This PR is the minimal surgical patch needed to land #52 cleanly: bump the deprecated pin, unblock #52's CI, merge #52 (which then removes the legacy workflows entirely).

## Test plan

- [ ] Merge this PR.
- [ ] Re-trigger #52's failing checks (\`gh run rerun --failed\` or push an empty commit).
- [ ] Verify \`Test library\` and \`Code Coverage\` proceed past \"Set up job\".
- [ ] Merge #52, which removes the legacy workflows entirely.